### PR TITLE
.NET build errors should fail Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ WORKDIR /dotnetapp/HiP-UserStore
 
 EXPOSE 5000
 
-RUN dotnet restore --no-cache
+RUN dotnet build
 RUN chmod +x /dotnetapp/HiP-UserStore/run.sh
 CMD /dotnetapp/HiP-UserStore/run.sh

--- a/HiP-UserStore/HiP-UserStore.csproj
+++ b/HiP-UserStore/HiP-UserStore.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <Target Name="NSwag" AfterTargets="Build">
-    <Exec Command="$(NSwagExe_Core20) webapi2swagger /assembly:$(TargetPath) /output:../$(ProjectName).Sdk/swagger.json" />
-	<Exec Command="$(NSwagExe_Core20) swagger2csclient /input:../$(ProjectName).Sdk/swagger.json /output:../$(ProjectName).Sdk/NSwag.g.cs /namespace:$(RootNamespace) /ClientBaseClass:NSwagClientBase /UseHttpClientCreationMethod:true" />
+    <Exec Command="/root/.nuget/packages/nswag.msbuild/11.11.0/build/NetCore20/dotnet-nswag.dll webapi2swagger /assembly:$(TargetPath) /output:../$(ProjectName).Sdk/swagger.json" />
+	<Exec Command="/root/.nuget/packages/nswag.msbuild/11.11.0/build/NetCore20/dotnet-nswag.dll swagger2csclient /input:../$(ProjectName).Sdk/swagger.json /output:../$(ProjectName).Sdk/NSwag.g.cs /namespace:$(RootNamespace) /ClientBaseClass:NSwagClientBase /UseHttpClientCreationMethod:true" />
   </Target>
 </Project>

--- a/HiP-UserStore/HiP-UserStore.csproj
+++ b/HiP-UserStore/HiP-UserStore.csproj
@@ -40,8 +40,8 @@
     <ProjectReference Include="..\HiP-UserStore.Model\HiP-UserStore.Model.csproj" />
   </ItemGroup>
 
-  <Target Name="NSwag" AfterTargets="Build">
-    <Exec Command="/root/.nuget/packages/nswag.msbuild/11.11.0/build/NetCore20/dotnet-nswag.dll webapi2swagger /assembly:$(TargetPath) /output:../$(ProjectName).Sdk/swagger.json" />
-	<Exec Command="/root/.nuget/packages/nswag.msbuild/11.11.0/build/NetCore20/dotnet-nswag.dll swagger2csclient /input:../$(ProjectName).Sdk/swagger.json /output:../$(ProjectName).Sdk/NSwag.g.cs /namespace:$(RootNamespace) /ClientBaseClass:NSwagClientBase /UseHttpClientCreationMethod:true" />
+  <Target Name="NSwag" AfterTargets="Build" Condition="'$(OS)'=='Windows_NT'">
+    <Exec Command="$(NSwagExe_Core20) webapi2swagger /assembly:$(TargetPath) /output:../$(ProjectName).Sdk/swagger.json" />
+	<Exec Command="$(NSwagExe_Core20) swagger2csclient /input:../$(ProjectName).Sdk/swagger.json /output:../$(ProjectName).Sdk/NSwag.g.cs /namespace:$(RootNamespace) /ClientBaseClass:NSwagClientBase /UseHttpClientCreationMethod:true" />
   </Target>
 </Project>

--- a/HiP-UserStore/run.sh
+++ b/HiP-UserStore/run.sh
@@ -1,3 +1,3 @@
 /mongodb-linux-x86_64-debian81-3.4.9/bin/mongod --noprealloc &
 sleep 5
-dotnet run
+dotnet run --no-build


### PR DESCRIPTION
1. "dotnet build" is now executed at image build time, not at Docker image execution time.
1. NSwag is now only executed on Windows, since execution on Linux results in errors (at the moment). This is mostly fine for now since TFS uses Windows and Docker uses Linux. This also means that HiP devs with non-Windows machines are out of luck for now, but this is a minor issue.