### PR TITLE
HIPCMS-905: UserStore-driven user registration

### DIFF
--- a/HiP-UserStore.Model/Rest/UserArgs.cs
+++ b/HiP-UserStore.Model/Rest/UserArgs.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace PaderbornUniversity.SILab.Hip.UserStore.Model.Rest
 {

--- a/HiP-UserStore.Model/Rest/UserArgs.cs
+++ b/HiP-UserStore.Model/Rest/UserArgs.cs
@@ -1,9 +1,10 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using Newtonsoft.Json;
+using System.ComponentModel.DataAnnotations;
 
 namespace PaderbornUniversity.SILab.Hip.UserStore.Model.Rest
 {
     /// <summary>
-    /// Arguments for creating a user.
+    /// Arguments for creating a user in UserStore.
     /// </summary>
     public class UserArgs
     {
@@ -14,5 +15,16 @@ namespace PaderbornUniversity.SILab.Hip.UserStore.Model.Rest
         public string FirstName { get; set; }
 
         public string LastName { get; set; }
+
+        public UserArgs()
+        {
+        }
+
+        public UserArgs(UserRegistrationArgs args)
+        {
+            Email = args.Email;
+            FirstName = args.FirstName;
+            LastName = args.LastName;
+        }
     }
 }

--- a/HiP-UserStore.Model/Rest/UserArgs.cs
+++ b/HiP-UserStore.Model/Rest/UserArgs.cs
@@ -1,10 +1,14 @@
-﻿namespace PaderbornUniversity.SILab.Hip.UserStore.Model.Rest
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace PaderbornUniversity.SILab.Hip.UserStore.Model.Rest
 {
     /// <summary>
     /// Arguments for creating a user.
     /// </summary>
     public class UserArgs
     {
+        [Required]
+        [EmailAddress]
         public string Email { get; set; }
 
         public string FirstName { get; set; }

--- a/HiP-UserStore.Model/Rest/UserRegistrationArgs.cs
+++ b/HiP-UserStore.Model/Rest/UserRegistrationArgs.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace PaderbornUniversity.SILab.Hip.UserStore.Model.Rest
 {

--- a/HiP-UserStore.Model/Rest/UserRegistrationArgs.cs
+++ b/HiP-UserStore.Model/Rest/UserRegistrationArgs.cs
@@ -1,0 +1,26 @@
+﻿using Newtonsoft.Json;
+using System.ComponentModel.DataAnnotations;
+
+namespace PaderbornUniversity.SILab.Hip.UserStore.Model.Rest
+{
+    /// <summary>
+    /// Arguments for creating a user in both, UserStore and Auth0.
+    /// </summary>
+    /// <remarks>
+    /// To prevent accidentally serializing and storing the password in the event store,
+    /// this type is intentionally not derived from <see cref="UserArgs"/>.
+    /// </remarks>
+    public class UserRegistrationArgs
+    {
+        [Required]
+        [EmailAddress]
+        public string Email { get; set; }
+
+        public string FirstName { get; set; }
+
+        public string LastName { get; set; }
+
+        [Required]
+        public string Password { get; set; }
+    }
+}

--- a/HiP-UserStore/Controllers/UsersController.cs
+++ b/HiP-UserStore/Controllers/UsersController.cs
@@ -221,7 +221,7 @@ namespace PaderbornUniversity.SILab.Hip.UserStore.Controllers
         [ProducesResponseType(201)]
         [ProducesResponseType(400)]
         [ProducesResponseType(409)] // User with same email already exists
-        public async Task<IActionResult> RegisterAsync([FromBody]UserArgs args, string password)
+        public async Task<IActionResult> RegisterAsync([FromBody]UserRegistrationArgs args)
         {
             if (!ModelState.IsValid)
                 return BadRequest(ModelState);
@@ -231,14 +231,14 @@ namespace PaderbornUniversity.SILab.Hip.UserStore.Controllers
 
             try
             {
-                var userId = await Auth.CreateUserAsync(args, password);
+                var userId = await Auth.CreateUserAsync(args);
 
                 var ev = new UserCreated
                 {
                     Id = _entityIndex.NextId(ResourceType.User),
                     UserId = userId,
                     Timestamp = DateTimeOffset.Now,
-                    Properties = args
+                    Properties = new UserArgs(args)
                 };
 
                 await _eventStore.AppendEventAsync(ev);

--- a/HiP-UserStore/Controllers/UsersController.cs
+++ b/HiP-UserStore/Controllers/UsersController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿using Auth0.Core.Exceptions;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using MongoDB.Driver;
@@ -179,31 +180,24 @@ namespace PaderbornUniversity.SILab.Hip.UserStore.Controllers
             return NoContent();
         }
 
-        [HttpPost("Invite")]
-        public IActionResult InviteUsers(/*InviteArgs args*/)
-        {
-            throw new NotImplementedException(); // TODO: Migrate from CmsWebApi
-        }
-
         /// <summary>
-        /// This method is intended to be called by Auth0.
-        /// A hook should be configured in Auth0 that calls this API after a user signed up.
+        /// Creates a user in UserStore without registration in Auth0. Should only be used manually for
+        /// maintenance/debugging purposes in cases where a user already exists in Auth0.
         /// </summary>
-        [HttpPost]
-        [ProducesResponseType(400)]
-        [ProducesResponseType(409)] // User with same ID already exists
+        [HttpPost("{userId}")]
         [ProducesResponseType(201)]
-        public async Task<IActionResult> RegisterAsync([FromBody]UserArgsAuth0 args)
+        [ProducesResponseType(400)]
+        [ProducesResponseType(409)] // User with same ID or email already exists
+        public async Task<IActionResult> PostAsync(string userId, [FromBody]UserArgs args)
         {
             if (!ModelState.IsValid)
                 return BadRequest(ModelState);
 
-            // Note: args.Id contains the ID of the new user, User.Identity.GetUserIdentity() is something else
-            // (because the HTTP request is not initiated by the user, but by the Auth0 system)
-            var userId = "auth0|" + args.Id;
-
             if (_userIndex.TryGetInternalId(userId, out var _))
                 return StatusCode(409, new { Message = $"A user with ID '{userId}' already exists" });
+
+            if (_userIndex.IsEmailInUse(args.Email))
+                return StatusCode(409, new { Message = $"A user with email address '{args.Email}' already exists" });
 
             var ev = new UserCreated
             {
@@ -221,6 +215,42 @@ namespace PaderbornUniversity.SILab.Hip.UserStore.Controllers
         }
 
         /// <summary>
+        /// Registers a new user in UserStore and Auth0.
+        /// </summary>
+        [HttpPost]
+        [ProducesResponseType(201)]
+        [ProducesResponseType(400)]
+        [ProducesResponseType(409)] // User with same email already exists
+        public async Task<IActionResult> RegisterAsync([FromBody]UserArgs args, string password)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            if (_userIndex.IsEmailInUse(args.Email))
+                return StatusCode(409, new { Message = $"A user with email address '{args.Email}' already exists" });
+
+            try
+            {
+                var userId = await Auth.CreateUserAsync(args, password);
+
+                var ev = new UserCreated
+                {
+                    Id = _entityIndex.NextId(ResourceType.User),
+                    UserId = userId,
+                    Timestamp = DateTimeOffset.Now,
+                    Properties = args
+                };
+
+                await _eventStore.AppendEventAsync(ev);
+                return Created($"{Request.Scheme}://{Request.Host}/api/Users/{userId}", userId);
+            }
+            catch (ApiException e)
+            {
+                return StatusCode(e.ApiError.StatusCode, e.ApiError.Message);
+            }
+        }
+
+        /// <summary>
         /// Updates the Auth0 roles of a user.
         /// </summary>
         [HttpPut("{userId}/Roles")]
@@ -230,6 +260,9 @@ namespace PaderbornUniversity.SILab.Hip.UserStore.Controllers
         [ProducesResponseType(404)]
         public async Task<IActionResult> PutRolesAsync(string userId, [FromBody]string[] roles)
         {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
             var invalidRoles = roles.Distinct().Where(s => !Enum.TryParse<UserRoles>(s, out _));
 
             foreach (var invalidRole in invalidRoles)

--- a/HiP-UserStore/Controllers/UsersController.cs
+++ b/HiP-UserStore/Controllers/UsersController.cs
@@ -215,7 +215,7 @@ namespace PaderbornUniversity.SILab.Hip.UserStore.Controllers
         }
 
         /// <summary>
-        /// Registers a new user in UserStore and Auth0.
+        /// Registers a new user in UserStore and Auth0 and assigns it the role 'Student'.
         /// </summary>
         [HttpPost]
         [ProducesResponseType(201)]

--- a/HiP-UserStore/Utility/Auth.cs
+++ b/HiP-UserStore/Utility/Auth.cs
@@ -120,7 +120,7 @@ namespace PaderbornUniversity.SILab.Hip.UserStore.Utility
         /// <exception cref="ArgumentNullException"/>
         /// <exception cref="ArgumentException">Email or password is missing</exception>
         /// <exception cref="ApiException">Auth0 reported an error during registration</exception>
-        public static async Task<string> CreateUserAsync(UserArgs args, string password)
+        public static async Task<string> CreateUserAsync(UserRegistrationArgs args)
         {
             if (args == null)
                 throw new ArgumentNullException(nameof(args));
@@ -128,8 +128,8 @@ namespace PaderbornUniversity.SILab.Hip.UserStore.Utility
             if (string.IsNullOrEmpty(args.Email))
                 throw new ArgumentException("Email is required", nameof(args));
 
-            if (string.IsNullOrEmpty(password))
-                throw new ArgumentException("Password is required", nameof(password));
+            if (string.IsNullOrEmpty(args.Password))
+                throw new ArgumentException("Password is required", nameof(args));
 
             var accessToken = await GetAccessTokenAsync();
             var management = new ManagementApiClient(accessToken, _authConfig.Domain);
@@ -139,7 +139,7 @@ namespace PaderbornUniversity.SILab.Hip.UserStore.Utility
                 FirstName = args.FirstName,
                 LastName = args.LastName,
                 FullName = string.Join(' ', args.FirstName.Trim() ?? "", args.LastName.Trim() ?? ""),
-                Password = password,
+                Password = args.Password,
                 AppMetadata = new { roles = new[] { UserRoles.Student.ToString() } },
                 Connection = "Username-Password-Authentication" // TODO: Make configurable
             });

--- a/HiP-UserStore/Utility/Auth.cs
+++ b/HiP-UserStore/Utility/Auth.cs
@@ -115,7 +115,7 @@ namespace PaderbornUniversity.SILab.Hip.UserStore.Utility
         }
 
         /// <summary>
-        /// Registers a new user in Auth0.
+        /// Registers a new user in Auth0 and assigns it the role 'Student'.
         /// </summary>
         /// <exception cref="ArgumentNullException"/>
         /// <exception cref="ArgumentException">Email or password is missing</exception>
@@ -138,7 +138,9 @@ namespace PaderbornUniversity.SILab.Hip.UserStore.Utility
                 Email = args.Email,
                 FirstName = args.FirstName,
                 LastName = args.LastName,
+                FullName = string.Join(' ', args.FirstName.Trim() ?? "", args.LastName.Trim() ?? ""),
                 Password = password,
+                AppMetadata = new { roles = new[] { UserRoles.Student.ToString() } },
                 Connection = "Username-Password-Authentication" // TODO: Make configurable
             });
 


### PR DESCRIPTION
**Currently, user registration works as follows:**
* User registers via Auth0 UI, new user is stored in Auth0 database
* Registration triggers a "post user registration"-hook which executes a small script
* This script sends a POST-request to UserStore so that the user is created there as well

**What's the disadvantage of the current registration flow?**
* User registration is likely considered successful on Auth0's side, even if the "post user registration"-hook fails
* Suppose UserStore is temporarily offline (e.g. during redeployment): The hook will fail, but the registration in Auth0 succeeds
* The result is that there's an inconsistency between Auth0 and UserStore: A user is registered in one database, but not the other

**How does this PR solve this?**
* The "entry point" for user registration is now UserStore instead of Auth0
* UserStore provides a method (POST /api/Users) to register new users
* This method creates a new user in both, Auth0 database and UserStore database (event store)
* We can't guarantee that both registration steps are successful, but
  * if Auth0-registration fails, the whole registration fails; data remains in sync
  * if Auth0-registration succeeds, but UserStore registration fails, data gets out of sync, but at least we log an error on what happened (this scenario will be very rare, though)

**What are the implications?**
* We now need to provide a custom UI for user registration, but that's what we wanted to do anyway