### PR TITLE
Bugfix in "POST /Users/{userId}" maintenance API

### DIFF
--- a/HiP-UserStore/Controllers/UsersController.cs
+++ b/HiP-UserStore/Controllers/UsersController.cs
@@ -210,6 +210,8 @@ namespace PaderbornUniversity.SILab.Hip.UserStore.Controllers
                 Properties = new UserArgs
                 {
                     Email = args.Email,
+                    FirstName = args.FirstName,
+                    LastName = args.LastName
                 }
             };
 


### PR DESCRIPTION
Fixed: When registering new users via the maintenance API `POST /Users/{userId}`, first name and last name are now saved correctly