### PR TITLE
[iss-hipcms-984] Fixed creation of Actions, added migrations for existing actions

### DIFF
--- a/HiP-UserStore/Controllers/ActionBaseController.cs
+++ b/HiP-UserStore/Controllers/ActionBaseController.cs
@@ -6,7 +6,6 @@ using PaderbornUniversity.SILab.Hip.UserStore.Core;
 using System.Threading.Tasks;
 using PaderbornUniversity.SILab.Hip.UserStore.Utility;
 using PaderbornUniversity.SILab.Hip.UserStore.Model.Rest;
-using PaderbornUniversity.SILab.Hip.UserStore.Model;
 
 namespace PaderbornUniversity.SILab.Hip.UserStore.Controllers
 {

--- a/HiP-UserStore/Controllers/ActionBaseController.cs
+++ b/HiP-UserStore/Controllers/ActionBaseController.cs
@@ -46,7 +46,7 @@ namespace PaderbornUniversity.SILab.Hip.UserStore.Controllers
             if (!validationResult.Success)
                 return validationResult.ActionResult;
 
-            var id = _entityIndex.NextId(ResourceTypes.Action);
+            var id = _entityIndex.NextId(ResourceType);
             await EntityManager.CreateEntityAsync(_eventStore, args, ResourceType, id, User.Identity.GetUserIdentity());
             return Created($"{Request.Scheme}://{Request.Host}/api/Action/{id}", id);
         }

--- a/HiP-UserStore/Migrations/Migration2FixReportedActionIds.cs
+++ b/HiP-UserStore/Migrations/Migration2FixReportedActionIds.cs
@@ -1,9 +1,6 @@
 ﻿using PaderbornUniversity.SILab.Hip.EventSourcing.Events;
 using PaderbornUniversity.SILab.Hip.EventSourcing.Migrations;
 using PaderbornUniversity.SILab.Hip.UserStore.Model;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace PaderbornUniversity.SILab.Hip.UserStore.Migrations

--- a/HiP-UserStore/Migrations/Migration2FixReportedActionIds.cs
+++ b/HiP-UserStore/Migrations/Migration2FixReportedActionIds.cs
@@ -1,0 +1,48 @@
+﻿using PaderbornUniversity.SILab.Hip.EventSourcing.Events;
+using PaderbornUniversity.SILab.Hip.EventSourcing.Migrations;
+using PaderbornUniversity.SILab.Hip.UserStore.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PaderbornUniversity.SILab.Hip.UserStore.Migrations
+{
+    [StreamMigration(from: 1, to: 2)]
+    public class Migration2FixReportedActionIds : IStreamMigration
+    {
+        public async Task MigrateAsync(IStreamMigrationArgs e)
+        {
+            var events = e.GetExistingEvents();
+            int lastIdSeen = 0;
+            int nextId = 0;
+            while (await events.MoveNextAsync())
+            {
+                switch (events.Current)
+                {
+                    case CreatedEvent ev when ev.GetEntityType() == ActionTypes.ExhibitVisited:
+                        if (ev.Id <= lastIdSeen)
+                        {
+                            ev.Id = nextId;
+                        }
+                        lastIdSeen = ev.Id;
+                        nextId++;
+                        e.AppendEvent(ev);
+                        break;
+
+                    case PropertyChangedEvent ev when ev.GetEntityType() == ActionTypes.ExhibitVisited:
+                        if (ev.Id <= lastIdSeen)
+                        {
+                            ev.Id = lastIdSeen;
+                        }
+                        e.AppendEvent(ev);
+                        break;
+
+                    default:
+                        e.AppendEvent(events.Current);
+                        break;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adresses an issue with the creation of Actions. The BaseController used the Action ResourceType for which no entities exist (because this is only the BaseResourceType). It also adds a Migration which fixes the ID's of the existing actions