### PR TITLE
Added filtering option for the beginning of an email

### DIFF
--- a/HiP-UserStore.Model/Rest/UserQueryArgs.cs
+++ b/HiP-UserStore.Model/Rest/UserQueryArgs.cs
@@ -6,5 +6,10 @@
         /// Restricts the response result to users having the specified role.
         /// </summary>
         public string Role { get; set; }
+
+        /// <summary>
+        /// Restricts the response to users having an email that begins with the specified string
+        /// </summary>
+        public string EmailBeginning { get; set; }
     }
 }

--- a/HiP-UserStore/Controllers/UsersController.cs
+++ b/HiP-UserStore/Controllers/UsersController.cs
@@ -72,6 +72,7 @@ namespace PaderbornUniversity.SILab.Hip.UserStore.Controllers
                     .Select(user => (user: user, roles: roles[user.UserId]))
                     .AsQueryable()
                     .FilterIf(!string.IsNullOrEmpty(args.Role), u => u.roles.Contains(args.Role))
+                    .FilterIf(!string.IsNullOrEmpty(args.EmailBeginning), u => u.user.Email != null && u.user.Email.StartsWith(args.EmailBeginning))
                     .Sort(args.OrderBy,
                         ("firstName", x => x.user.FirstName),
                         ("lastName", x => x.user.LastName),


### PR DESCRIPTION
For the preview in the CMS we need to be able to filter by the string that an email starts with. This option is added with this PR