### PR TITLE
HIPCMS-1063 Rework Activity Stream

### DIFF
--- a/HiP-UserStore/Controllers/ActivityController.cs
+++ b/HiP-UserStore/Controllers/ActivityController.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
 using PaderbornUniversity.SILab.Hip.DataStore;
 using PaderbornUniversity.SILab.Hip.EventSourcing;
 using PaderbornUniversity.SILab.Hip.UserStore.Core;

--- a/HiP-UserStore/Controllers/ActivityController.cs
+++ b/HiP-UserStore/Controllers/ActivityController.cs
@@ -17,13 +17,11 @@ namespace PaderbornUniversity.SILab.Hip.UserStore.Controllers
     [Authorize]
     public class ActivityController : Controller
     {
-        private readonly EndpointConfig _endpointConfig;
         private readonly DataStoreService _dataStoreService;
         private readonly ActivityIndex _activityIndex;
 
         public ActivityController(IOptions<EndpointConfig> endpointConfig, DataStoreService dataStoreService, InMemoryCache cache)
         {
-            _endpointConfig = endpointConfig.Value;
             _dataStoreService = dataStoreService;
             _activityIndex = cache.Index<ActivityIndex>();
         }
@@ -127,7 +125,6 @@ namespace PaderbornUniversity.SILab.Hip.UserStore.Controllers
                 return BadRequest(ModelState);
 
             var userId = User.Identity.GetUserIdentity();
-            var token = Request.Headers["Authorization"];
 
             var media = await GetContentIdsAsync(status, ResourceTypes.Media);
             media = await RemoveIdsAsync(media, ResourceTypes.Media, userId, _activityIndex.GetTimestamp(userId, ResourceTypes.Media));

--- a/HiP-UserStore/Controllers/ActivityController.cs
+++ b/HiP-UserStore/Controllers/ActivityController.cs
@@ -20,7 +20,7 @@ namespace PaderbornUniversity.SILab.Hip.UserStore.Controllers
         private readonly DataStoreService _dataStoreService;
         private readonly ActivityIndex _activityIndex;
 
-        public ActivityController(IOptions<EndpointConfig> endpointConfig, DataStoreService dataStoreService, InMemoryCache cache)
+        public ActivityController(DataStoreService dataStoreService, InMemoryCache cache)
         {
             _dataStoreService = dataStoreService;
             _activityIndex = cache.Index<ActivityIndex>();

--- a/HiP-UserStore/Core/ActivityIndex.cs
+++ b/HiP-UserStore/Core/ActivityIndex.cs
@@ -32,13 +32,16 @@ namespace PaderbornUniversity.SILab.Hip.UserStore.Core
 
         public void UpdateAllTimestamps (string userId, DateTimeOffset time)
         {
-            if (_userTimestamps.ContainsKey(userId))
+            lock (_lockObject)
             {
-                var tempTypeDict = new Dictionary<ResourceType, DateTimeOffset>(_userTimestamps[userId]);
-
-                foreach (var type in tempTypeDict)
+                if (_userTimestamps.ContainsKey(userId))
                 {
-                    _userTimestamps[userId][type.Key] = time;
+                    var tempTypeDict = new Dictionary<ResourceType, DateTimeOffset>(_userTimestamps[userId]);
+
+                    foreach (var type in tempTypeDict)
+                    {
+                        _userTimestamps[userId][type.Key] = time;
+                    }
                 }
             }
         }

--- a/HiP-UserStore/Core/ActivityIndex.cs
+++ b/HiP-UserStore/Core/ActivityIndex.cs
@@ -1,0 +1,96 @@
+﻿using PaderbornUniversity.SILab.Hip.EventSourcing;
+using PaderbornUniversity.SILab.Hip.EventSourcing.Events;
+using PaderbornUniversity.SILab.Hip.UserStore.Model;
+using System;
+using System.Collections.Generic;
+
+namespace PaderbornUniversity.SILab.Hip.UserStore.Core
+{
+    public class ActivityIndex : IDomainIndex
+    {
+        private readonly Dictionary<string, Dictionary<ResourceType, DateTimeOffset>> _userTimestamps 
+            = new Dictionary<string, Dictionary<ResourceType, DateTimeOffset>>();
+        private readonly object _lockObject = new object();
+
+        public void UpdateTimestamp (string userId, DateTimeOffset timestamp, ResourceType type)
+        {
+            lock (_lockObject)
+            {
+                if (_userTimestamps.ContainsKey(userId))
+                {
+                    if (_userTimestamps[userId].ContainsKey(type))
+                    {
+                        _userTimestamps[userId][type] = timestamp;
+                    }
+                }
+                else
+                {
+                    _userTimestamps.Add(userId, InitTypeDict());
+                }
+            }
+        }
+
+        public void UpdateAllTimestamps (string userId, DateTimeOffset time)
+        {
+            if (_userTimestamps.ContainsKey(userId))
+            {
+                var tempTypeDict = new Dictionary<ResourceType, DateTimeOffset>(_userTimestamps[userId]);
+
+                foreach (var type in tempTypeDict)
+                {
+                    _userTimestamps[userId][type.Key] = time;
+                }
+            }
+        }
+
+        public DateTimeOffset GetTimestamp (string userId, ResourceType type)
+        {
+            lock (_lockObject)
+            {
+                if (_userTimestamps.TryGetValue(userId, out var types))
+                {
+                    if (types.TryGetValue(type, out var timestamp))
+                    {
+                        return timestamp;
+                    }
+                }
+                else
+                {
+                    _userTimestamps.Add(userId, InitTypeDict());
+                }
+
+                return DateTimeOffset.MinValue;
+            }
+        }
+
+        public void ApplyEvent(IEvent e)
+        {
+            switch (e)
+            {
+                case PropertyChangedEvent ev:
+                    var resourceType = ev.GetEntityType();
+                    if (resourceType == ResourceTypes.User && ev.PropertyName == "UserId")
+                    {
+                        lock (_lockObject)
+                        {
+                            if (!_userTimestamps.ContainsKey(ev.Value.ToString()))
+                            {
+                                _userTimestamps.Add(ev.Value.ToString(), InitTypeDict());
+                            }
+                        }
+                    }
+                    break;
+            }
+        }
+
+        public Dictionary<ResourceType, DateTimeOffset> InitTypeDict() =>
+            new Dictionary<ResourceType, DateTimeOffset>
+            {
+                { ResourceTypes.Exhibit, DateTimeOffset.MinValue },
+                { ResourceTypes.Route, DateTimeOffset.MinValue },
+                { ResourceTypes.Tag, DateTimeOffset.MinValue },
+                { ResourceTypes.Media, DateTimeOffset.MinValue },
+                { ResourceTypes.ExhibitPage, DateTimeOffset.MinValue }
+            };
+    }
+}

--- a/HiP-UserStore/Startup.cs
+++ b/HiP-UserStore/Startup.cs
@@ -57,7 +57,8 @@ namespace PaderbornUniversity.SILab.Hip.UserStore
                 .AddSingleton<DataStoreService>()
                 .AddSingleton<IDomainIndex, EntityIndex>()
                 .AddSingleton<IDomainIndex, ExhibitsVisitedIndex>()
-                .AddSingleton<IDomainIndex, UserIndex>();
+                .AddSingleton<IDomainIndex, UserIndex>()
+                .AddSingleton<IDomainIndex, ActivityIndex>();
 
             var serviceProvider = services.BuildServiceProvider(); // allows us to actually get the configured services
             var authConfig = serviceProvider.GetService<IOptions<UserStoreAuthConfig>>();


### PR DESCRIPTION
The ActivityController was changed, s.t. the DataStore.Sdk is used when requests are send to the DataStore, and an ActivityIndex was created, which saves a timestamp for each user, so only activities that took place after this time are considered by the activity stream. 